### PR TITLE
Improve Firefox/Safari spoiler fallback with animated canvas rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Inspired by [Telegram spoilers](https://telegram.org/blog/reactions-spoilers-tra
 hidden until revealed.
 
 - Uses **[CSS Painting API](https://caniuse.com/css-paint-api) (Houdini)** to achive realistic
-  rendering for inline elements. Comes with a static image **fallback**;
+  rendering for inline elements. Comes with an animated canvas **fallback** for browsers without
+  Houdini support;
 - Supports **light/dark/system** mode;
 - Animated **content transitions** (_fade/iris_), or custom;
 - Respects `prefers-reduced-motion`;
 - Control the performance: **FPS**, **density**, **color**, and more;
 
 > CSS Painting API is still [unsupported](https://caniuse.com/css-paint-api) in Firefox and Safari.
-> We provide a static fallback image for these browsers, that you can customise via the `fallback`
-> prop. Also, there is a [polyfill](https://github.com/GoogleChromeLabs/css-paint-polyfill)
-> available.
+> We provide an animated fallback for these browsers. You can still customise the static backup via
+> the `fallback` prop if canvas rendering is unavailable.
 
 ### How to use?
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ You can also use `fps` and `density` props to control the performance:
 When applied to inline elements, `<Spoiler />` will try to mimic the shape of the words in a
 paragraph (faking spaces between words).
 
+This is currently available only on the Houdini path. Fallback browsers render animated line boxes
+without word-gap mimicry.
+
 Since it can be inaccurate, use `mimicWords` setting to disable it:
 
 ```jsx

--- a/src/SpoilerPainter.ts
+++ b/src/SpoilerPainter.ts
@@ -12,6 +12,7 @@ export interface SpoilerPainterOptions {
   readonly fps?: number;
   readonly gap?: number | boolean;
   readonly density?: number;
+  // `mimicWords` affects only the Houdini path. Fallback browsers render line boxes without word gaps.
   readonly mimicWords?: boolean;
   readonly accentColor?: string;
   readonly fallback?: string | false;
@@ -294,7 +295,6 @@ class SpoilerPainter {
     this.#t0 = now;
 
     if (!isCSSHoudiniSupported || this.#forceFallback) {
-      this.#fallback.syncGeometry();
       this.#fallback.drawFrame();
     }
   };
@@ -304,10 +304,6 @@ class SpoilerPainter {
   #raf: ReturnType<typeof requestAnimationFrame> | null = null;
 
   startAnimation() {
-    if (!isCSSHoudiniSupported || this.#forceFallback) {
-      this.#fallback.updateSurface(this.#lastGap);
-    }
-
     this.#t0 = performance.now();
     this.#frame(this.#t0);
   }
@@ -334,6 +330,9 @@ class SpoilerPainter {
           if (!entry.isIntersecting) {
             this.stopAnimation();
           } else {
+            if (!isCSSHoudiniSupported || this.#forceFallback) {
+              this.#fallback.updateSurface(this.#lastGap);
+            }
             this.startAnimation();
           }
         });
@@ -348,9 +347,11 @@ class SpoilerPainter {
   }
 
   showFallback() {
-    this.#fallback.show(this.#fadeDuration);
+    const shouldDrawImmediately = this.maxFPS <= 0;
+    if (!this.#fallback.show(this.#fadeDuration, shouldDrawImmediately)) return;
     this.#tstop = null;
     this.t = 0;
+    if (shouldDrawImmediately) return;
     this.startAnimation();
   }
 
@@ -362,7 +363,7 @@ class SpoilerPainter {
 
 declare global {
   namespace CSS {
-    namespace paintWorklet {
+    module paintWorklet {
       function addModule(moduleURL: string): Promise<void>;
     }
   }

--- a/src/SpoilerPainter.ts
+++ b/src/SpoilerPainter.ts
@@ -1,5 +1,6 @@
 import { colord } from "colord";
 import workletSource from "./worklet.js?raw";
+import { SpoilerPainterFallback } from "./SpoilerPainterFallback";
 
 export const isCSSHoudiniSupported = typeof CSS !== "undefined" && CSS.paintWorklet !== undefined;
 
@@ -58,10 +59,16 @@ class SpoilerPainter {
   readonly el: HTMLElement;
   maxFPS: number = DEFAULT_FPS;
 
+  #fallback: SpoilerPainterFallback;
   #forceFallback: boolean = false;
+  #lastGap: number | boolean = DEFAULT_OPTIONS.gap;
 
   constructor(el: HTMLElement, options: CtorOptions = {}) {
     this.el = el;
+    this.#fallback = new SpoilerPainterFallback(el, {
+      defaultDensity: DEFAULT_OPTIONS.density,
+      defaultGap: DEFAULT_OPTIONS.gap,
+    });
 
     this.#tstop = 0;
     this.update(options);
@@ -80,6 +87,7 @@ class SpoilerPainter {
   destroy() {
     this.#wasDestroyed = true;
     this.stopAnimation();
+    this.#fallback.destroy();
 
     ["background", "--t", "--t-stop", "--fade", "--gap", "--words", "--density"].forEach((prop) => {
       this.el.style.removeProperty(prop);
@@ -115,11 +123,25 @@ class SpoilerPainter {
     // disable animation if the user has requested reduced motion
     this.maxFPS = prefersReducedMotion ? 0 : fps;
     this.#forceFallback = Boolean(forceFallback);
+    this.#lastGap = gap;
+
+    this.el.style.setProperty("--words", String(mimicWords));
+    this.el.style.setProperty("--density", String(density));
+
+    if (accentColor) {
+      const hsl = colord(accentColor).toHsl();
+      this.el.style.setProperty("--accent", `${hsl.h}deg ${hsl.s}% ${hsl.l}%`);
+    } else {
+      this.el.style.removeProperty("--accent");
+    }
 
     if (!isCSSHoudiniSupported || forceFallback) {
       this.el.style.setProperty("--fallback", fallback || "initial");
+      this.#fallback.updateSurface(gap);
       return;
     }
+
+    this.#fallback.destroy();
 
     const isBlockElement = getComputedStyle(this.el).getPropertyValue("display") !== "inline";
     this.useBackgroundStyle("auto", "auto", { tile: false });
@@ -146,28 +168,17 @@ class SpoilerPainter {
 
         this.el.style.setProperty("--gap", `${capGap}px ${capGap}px`);
       }
+
+      return;
     }
 
-    if (!isBlockElement) {
-      const rects = [...this.el.getClientRects()];
-      const heightOfLine = Math.min(...rects.map((r) => r.height));
+    const rects = [...this.el.getClientRects()];
+    const heightOfLine = Math.min(...rects.map((r) => r.height));
 
-      this.useBackgroundStyle(INLINE_MAX_TILE, heightOfLine, { tile: true });
+    this.useBackgroundStyle(INLINE_MAX_TILE, heightOfLine, { tile: true });
 
-      // use top/bottom gaps only
-      const capGap = Math.floor(Math.min(heightOfLine / GAP_RATIO, Number(gap)));
-      this.el.style.setProperty("--gap", `0 ${capGap}px`);
-    }
-
-    this.el.style.setProperty("--words", String(mimicWords));
-    this.el.style.setProperty("--density", String(density));
-
-    if (accentColor) {
-      const hsl = colord(accentColor).toHsl();
-      this.el.style.setProperty("--accent", `${hsl.h}deg ${hsl.s}% ${hsl.l}%`);
-    } else {
-      this.el.style.removeProperty("--accent");
-    }
+    const capGap = Math.floor(Math.min(heightOfLine / GAP_RATIO, Number(gap)));
+    this.el.style.setProperty("--gap", `0 ${capGap}px`);
   }
 
   useBackgroundStyle(ws: string | number, hs: string | number, options?: { tile: boolean }) {
@@ -201,19 +212,18 @@ class SpoilerPainter {
   parseFadeDuration(value: number | boolean | undefined) {
     if (prefersReducedMotion) return 0;
 
-    const duration = value === true ? DEFAULT_FADE_DURATION : Number(value);
-    return duration;
+    return value === true ? DEFAULT_FADE_DURATION : Number(value);
   }
 
   hide({ animate = true }: TransitionOptions = {}) {
     this.#isHidden = true;
+    this.#fadeDuration = this.parseFadeDuration(animate);
 
     if (!isCSSHoudiniSupported || this.#forceFallback) {
-      this.el.style.setProperty("background", "var(--fallback)");
+      this.showFallback();
       return;
     }
 
-    this.#fadeDuration = this.parseFadeDuration(animate);
     this.#tstop = null; // reset the stop point
     this.t = 0; // reset the clock
 
@@ -222,15 +232,14 @@ class SpoilerPainter {
 
   reveal({ animate = true }: TransitionOptions = {}) {
     this.#isHidden = false;
+    const duration = this.parseFadeDuration(animate);
+    this.#fadeDuration = duration;
 
     if (!isCSSHoudiniSupported || this.#forceFallback) {
-      this.el.style.removeProperty("background");
+      this.hideFallback();
       return;
     }
 
-    const duration = this.parseFadeDuration(animate);
-
-    this.#fadeDuration = duration;
     this.#tstop = this.t;
 
     if (duration <= 0) {
@@ -283,6 +292,11 @@ class SpoilerPainter {
 
     this.t += dt / 1000; // in seconds
     this.#t0 = now;
+
+    if (!isCSSHoudiniSupported || this.#forceFallback) {
+      this.#fallback.syncGeometry();
+      this.#fallback.drawFrame();
+    }
   };
 
   /** Animation state */
@@ -290,6 +304,10 @@ class SpoilerPainter {
   #raf: ReturnType<typeof requestAnimationFrame> | null = null;
 
   startAnimation() {
+    if (!isCSSHoudiniSupported || this.#forceFallback) {
+      this.#fallback.updateSurface(this.#lastGap);
+    }
+
     this.#t0 = performance.now();
     this.#frame(this.#t0);
   }
@@ -328,11 +346,23 @@ class SpoilerPainter {
 
     this.#observer.observe(this.el);
   }
+
+  showFallback() {
+    this.#fallback.show(this.#fadeDuration);
+    this.#tstop = null;
+    this.t = 0;
+    this.startAnimation();
+  }
+
+  hideFallback() {
+    this.stopAnimation();
+    this.#fallback.hide(this.#fadeDuration);
+  }
 }
 
 declare global {
   namespace CSS {
-    module paintWorklet {
+    namespace paintWorklet {
       function addModule(moduleURL: string): Promise<void>;
     }
   }

--- a/src/SpoilerPainter.ts
+++ b/src/SpoilerPainter.ts
@@ -363,7 +363,7 @@ class SpoilerPainter {
 
 declare global {
   namespace CSS {
-    module paintWorklet {
+    namespace paintWorklet {
       function addModule(moduleURL: string): Promise<void>;
     }
   }

--- a/src/SpoilerPainterFallback.test.ts
+++ b/src/SpoilerPainterFallback.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SpoilerPainter } from "./SpoilerPainter";
+import { SpoilerPainterFallback } from "./SpoilerPainterFallback";
+import { SpoilerPainterWorklet } from "./worklet.js";
+
+const fakeContext = {} as CanvasRenderingContext2D;
+
+describe("SpoilerPainterFallback", () => {
+  let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+  let originalRAF: typeof globalThis.requestAnimationFrame;
+
+  beforeEach(() => {
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+    originalRAF = globalThis.requestAnimationFrame;
+
+    HTMLCanvasElement.prototype.getContext = vi.fn(
+      () => fakeContext,
+    ) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    globalThis.requestAnimationFrame = vi.fn(() => 1) as typeof requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    globalThis.requestAnimationFrame = originalRAF;
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("does not clear host inline styles when destroyed before a surface is created", () => {
+    const el = document.createElement("div");
+    el.style.overflow = "visible";
+    el.style.position = "sticky";
+
+    const fallback = new SpoilerPainterFallback(el, {
+      defaultDensity: 0.12,
+      defaultGap: 6,
+    });
+
+    fallback.destroy();
+
+    expect(el.style.overflow).toBe("visible");
+    expect(el.style.position).toBe("sticky");
+  });
+
+  it("passes through the configured density and disables word gaps in fallback mode", () => {
+    const el = document.createElement("span");
+    document.body.appendChild(el);
+
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 120,
+      height: 24,
+      right: 130,
+      bottom: 44,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(el, "getClientRects").mockReturnValue([
+      {
+        left: 10,
+        top: 20,
+        width: 120,
+        height: 24,
+        right: 130,
+        bottom: 44,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      },
+    ] as any);
+
+    let observedDensity: string | undefined;
+    let observedWords: string | undefined;
+    vi.spyOn(SpoilerPainterWorklet.prototype, "paint").mockImplementation((_ctx, _size, props) => {
+      observedDensity = props.get("--density");
+      observedWords = props.get("--words");
+    });
+
+    el.style.setProperty("--density", "0.42");
+
+    const fallback = new SpoilerPainterFallback(el, {
+      defaultDensity: 0.12,
+      defaultGap: 6,
+    });
+
+    fallback.updateSurface(6);
+
+    expect(observedDensity).toBe("0.42");
+    expect(observedWords).toBe("false");
+  });
+
+  it("does not update the fallback surface twice when revealing", () => {
+    const el = document.createElement("span");
+    document.body.appendChild(el);
+
+    const updateSurfaceSpy = vi
+      .spyOn(SpoilerPainterFallback.prototype, "updateSurface")
+      .mockReturnValue(true);
+    vi.spyOn(SpoilerPainterFallback.prototype, "show").mockReturnValue(true);
+    vi.spyOn(SpoilerPainterFallback.prototype, "drawFrame").mockImplementation(() => {});
+
+    const painter = new SpoilerPainter(el, { forceFallback: true });
+
+    painter.hide();
+
+    expect(updateSurfaceSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/SpoilerPainterFallback.ts
+++ b/src/SpoilerPainterFallback.ts
@@ -1,0 +1,366 @@
+import { SpoilerPainterWorklet } from "./worklet.js";
+
+type PaintPropertyMapLike = {
+  get(name: string): string | undefined;
+};
+
+type SpoilerPaintRenderer = {
+  paint(
+    ctx: CanvasRenderingContext2D,
+    size: { width: number; height: number },
+    props: PaintPropertyMapLike,
+  ): void;
+};
+
+type FallbackMode = "none" | "block" | "inline";
+
+type FallbackFragment = {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+type FallbackLayout = {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+  readonly fragments: FallbackFragment[];
+};
+
+type FallbackCanvas = {
+  readonly canvas: HTMLCanvasElement;
+  readonly ctx: CanvasRenderingContext2D;
+};
+
+const GAP_RATIO = 8.0;
+
+export type SpoilerPainterFallbackOptions = {
+  readonly defaultDensity: number;
+  readonly defaultGap: number | boolean;
+};
+
+type SurfaceResult = boolean;
+
+export class SpoilerPainterFallback {
+  readonly el: HTMLElement;
+  readonly #painter: SpoilerPaintRenderer = new SpoilerPainterWorklet();
+  readonly #defaultDensity: number;
+  readonly #defaultGap: number | boolean;
+
+  #mode: FallbackMode = "none";
+  #root: HTMLDivElement | null = null;
+  #canvases: FallbackCanvas[] = [];
+  #layout: FallbackLayout | null = null;
+  // Keep the fallback canvases sharp by sizing their backing bitmaps to the current DPR.
+  #dpr = 1;
+  #inlinePosition = "";
+  #inlineOverflow = "";
+  #inlinePositioning = false;
+  #viewportListeners = false;
+  #lastGap: number | boolean;
+
+  readonly #handleScroll = () => {
+    this.syncGeometry();
+  };
+
+  readonly #handleResize = () => {
+    this.updateSurface(this.#lastGap);
+  };
+
+  constructor(el: HTMLElement, options: SpoilerPainterFallbackOptions) {
+    this.el = el;
+    this.#defaultDensity = options.defaultDensity;
+    this.#defaultGap = options.defaultGap;
+    this.#lastGap = options.defaultGap;
+  }
+
+  destroy() {
+    this.attachViewportListeners(false);
+
+    this.#canvases.forEach(({ canvas }) => canvas.remove());
+    this.#canvases = [];
+    this.#layout = null;
+
+    if (this.#root) {
+      this.#root.remove();
+      this.#root = null;
+    }
+
+    if (this.#inlinePositioning) {
+      this.el.style.position = this.#inlinePosition;
+      this.#inlinePositioning = false;
+    }
+
+    this.el.style.overflow = this.#inlineOverflow;
+    this.#mode = "none";
+  }
+
+  updateSurface(gap: number | boolean | undefined): SurfaceResult {
+    if (typeof document === "undefined") return false;
+
+    const mode = getComputedStyle(this.el).getPropertyValue("display") === "inline" ? "inline" : "block";
+    if (!this.ensureSurface(mode)) {
+      return false;
+    }
+
+    this.#lastGap = gap ?? this.#defaultGap;
+    this.#dpr = Math.max(1, Math.round(globalThis.devicePixelRatio || 1));
+
+    if (!this.syncGeometry()) {
+      return false;
+    }
+
+    this.el.style.setProperty("--gap", this.getGap(mode, this.#lastGap));
+    this.attachViewportListeners(mode === "inline");
+    this.drawFrame();
+
+    return true;
+  }
+
+  show(duration: number) {
+    if (!this.updateSurface(this.#lastGap) || !this.#root) {
+      this.el.style.setProperty("background", "var(--fallback)");
+      return;
+    }
+
+    this.el.style.removeProperty("background");
+    this.#root.style.transitionDuration = `${duration}s`;
+    this.#root.style.opacity = "1";
+  }
+
+  hide(duration: number) {
+    if (this.#root) {
+      this.#root.style.transitionDuration = `${duration}s`;
+      this.#root.style.opacity = "0";
+    }
+
+    this.el.style.removeProperty("background");
+  }
+
+  syncGeometry() {
+    if (!this.#root || this.#mode === "none") return false;
+
+    const layout = this.getLayout(this.#mode);
+    if (!layout) return false;
+
+    this.#layout = layout;
+
+    if (this.#mode === "inline") {
+      this.#root.style.left = `${layout.left}px`;
+      this.#root.style.top = `${layout.top}px`;
+      this.#root.style.width = `${layout.width}px`;
+      this.#root.style.height = `${layout.height}px`;
+    }
+
+    this.syncCanvases(layout.fragments);
+    return true;
+  }
+
+  drawFrame() {
+    this.#canvases.forEach(({ canvas, ctx }) => {
+      const width = canvas.width;
+      const height = canvas.height;
+
+      if (width <= 0 || height <= 0) return;
+
+      ctx.clearRect(0, 0, width, height);
+      this.#painter.paint(ctx, { width, height }, this.getPropertyMap());
+    });
+  }
+
+  getDensity() {
+    const rawDensity = parseFloat(this.el.style.getPropertyValue("--density"));
+    const density = Number.isFinite(rawDensity) ? rawDensity : this.#defaultDensity;
+    const accent = this.el.style.getPropertyValue("--accent") || "";
+    const parts = accent.trim().split(/\s+/);
+    const lightness = parseFloat(parts[2] || "");
+
+    if (Number.isFinite(lightness) && lightness > 50) {
+      return density * 1.7;
+    }
+
+    return density;
+  }
+
+  ensureSurface(mode: Exclude<FallbackMode, "none">) {
+    if (this.#mode !== "none" && this.#mode !== mode) {
+      this.destroy();
+    }
+
+    if (this.#root) {
+      return true;
+    }
+
+    const root = document.createElement("div");
+    root.setAttribute("aria-hidden", "true");
+    root.style.pointerEvents = "none";
+    root.style.opacity = "0";
+    root.style.transitionProperty = "opacity";
+
+    if (mode === "block") {
+      if (getComputedStyle(this.el).position === "static") {
+        this.#inlinePosition = this.el.style.position;
+        this.el.style.position = "relative";
+        this.#inlinePositioning = true;
+      }
+
+      this.#inlineOverflow = this.el.style.overflow;
+      this.el.style.overflow = "hidden";
+
+      root.style.position = "absolute";
+      root.style.inset = "0";
+      root.style.zIndex = "0";
+      this.el.prepend(root);
+    } else {
+      root.style.position = "absolute";
+      root.style.left = "0";
+      root.style.top = "0";
+      root.style.zIndex = "2147483647";
+      document.body.appendChild(root);
+    }
+
+    this.#mode = mode;
+    this.#root = root;
+    this.#canvases = [];
+
+    return true;
+  }
+
+  attachViewportListeners(enabled: boolean) {
+    if (enabled === this.#viewportListeners) return;
+
+    this.#viewportListeners = enabled;
+
+    if (enabled) {
+      globalThis.addEventListener("scroll", this.#handleScroll, true);
+      globalThis.addEventListener("resize", this.#handleResize);
+      return;
+    }
+
+    globalThis.removeEventListener("scroll", this.#handleScroll, true);
+    globalThis.removeEventListener("resize", this.#handleResize);
+  }
+
+  getLayout(mode: Exclude<FallbackMode, "none">): FallbackLayout | null {
+    const bounds = this.el.getBoundingClientRect();
+    const width = Math.max(1, Math.ceil(bounds.width));
+    const height = Math.max(1, Math.ceil(bounds.height));
+
+    if (mode === "block") {
+      return {
+        left: 0,
+        top: 0,
+        width,
+        height,
+        fragments: [{ x: 0, y: 0, width, height }],
+      };
+    }
+
+    const left = Math.round(bounds.left + globalThis.scrollX);
+    const top = Math.round(bounds.top + globalThis.scrollY);
+
+    const fragments = [...this.el.getClientRects()]
+      .map((rect) => ({
+        x: Math.round(rect.left + globalThis.scrollX - left),
+        y: Math.round(rect.top + globalThis.scrollY - top),
+        width: Math.ceil(rect.width),
+        height: Math.ceil(rect.height),
+      }))
+      .filter((rect) => rect.width > 0 && rect.height > 0);
+
+    if (fragments.length === 0) {
+      return {
+        left,
+        top,
+        width,
+        height,
+        fragments: [{ x: 0, y: 0, width, height }],
+      };
+    }
+
+    return {
+      left,
+      top,
+      width,
+      height,
+      fragments,
+    };
+  }
+
+  syncCanvases(fragments: readonly FallbackFragment[]) {
+    if (!this.#root) return;
+
+    while (this.#canvases.length < fragments.length) {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+
+      if (!ctx) {
+        this.el.style.setProperty("background", "var(--fallback)");
+        return;
+      }
+
+      canvas.style.position = "absolute";
+      canvas.style.pointerEvents = "none";
+      this.#root.appendChild(canvas);
+      this.#canvases.push({ canvas, ctx });
+    }
+
+    while (this.#canvases.length > fragments.length) {
+      this.#canvases.pop()?.canvas.remove();
+    }
+
+    fragments.forEach((fragment, index) => {
+      const { canvas } = this.#canvases[index];
+      const pixelWidth = Math.max(1, fragment.width * this.#dpr);
+      const pixelHeight = Math.max(1, fragment.height * this.#dpr);
+
+      canvas.style.left = `${fragment.x}px`;
+      canvas.style.top = `${fragment.y}px`;
+      canvas.style.width = `${fragment.width}px`;
+      canvas.style.height = `${fragment.height}px`;
+
+      if (canvas.width !== pixelWidth) canvas.width = pixelWidth;
+      if (canvas.height !== pixelHeight) canvas.height = pixelHeight;
+    });
+  }
+
+  getGap(mode: Exclude<FallbackMode, "none">, gap: number | boolean | undefined) {
+    const value = gap === false ? 0 : Number(gap ?? this.#defaultGap);
+    const capGap = Number.isFinite(value) ? Math.floor(Math.max(0, value)) : 0;
+
+    if (mode === "block") {
+      const layout = this.#layout;
+      const width = layout?.width ?? 0;
+      const height = layout?.height ?? 0;
+      const blockGap = Math.floor(Math.min(capGap, width / GAP_RATIO, height / GAP_RATIO));
+
+      return `${blockGap}px ${blockGap}px`;
+    }
+
+    const lineHeight = Math.min(...(this.#layout?.fragments.map((rect) => rect.height) ?? [0]));
+    return `0px ${Math.floor(Math.min(lineHeight / GAP_RATIO, capGap))}px`;
+  }
+
+  getPropertyMap(): PaintPropertyMapLike {
+    return {
+      get: (name: string) => {
+        switch (name) {
+          case "--t":
+          case "--t-stop":
+          case "--fade":
+          case "--gap":
+          case "--accent":
+            return this.el.style.getPropertyValue(name) || undefined;
+          case "--words":
+            return "false";
+          case "--density":
+            return String(this.getDensity());
+          default:
+            return undefined;
+        }
+      },
+    };
+  }
+}

--- a/src/SpoilerPainterFallback.ts
+++ b/src/SpoilerPainterFallback.ts
@@ -35,13 +35,12 @@ type FallbackCanvas = {
 };
 
 const GAP_RATIO = 8.0;
+const HIGH_Z_INDEX = "2147483647";
 
 export type SpoilerPainterFallbackOptions = {
   readonly defaultDensity: number;
   readonly defaultGap: number | boolean;
 };
-
-type SurfaceResult = boolean;
 
 export class SpoilerPainterFallback {
   readonly el: HTMLElement;
@@ -56,17 +55,19 @@ export class SpoilerPainterFallback {
   // Keep the fallback canvases sharp by sizing their backing bitmaps to the current DPR.
   #dpr = 1;
   #inlinePosition = "";
-  #inlineOverflow = "";
   #inlinePositioning = false;
   #viewportListeners = false;
   #lastGap: number | boolean;
+  #refreshRAF: ReturnType<typeof requestAnimationFrame> | null = null;
+  #refreshNeedsDraw = false;
+  #refreshNeedsSurface = false;
 
   readonly #handleScroll = () => {
     this.syncGeometry();
   };
 
   readonly #handleResize = () => {
-    this.updateSurface(this.#lastGap);
+    this.scheduleRefresh({ draw: true, surface: true });
   };
 
   constructor(el: HTMLElement, options: SpoilerPainterFallbackOptions) {
@@ -77,11 +78,20 @@ export class SpoilerPainterFallback {
   }
 
   destroy() {
+    if (this.#mode === "none") return;
+
     this.attachViewportListeners(false);
+
+    if (this.#refreshRAF !== null) {
+      cancelAnimationFrame(this.#refreshRAF);
+      this.#refreshRAF = null;
+    }
 
     this.#canvases.forEach(({ canvas }) => canvas.remove());
     this.#canvases = [];
     this.#layout = null;
+    this.#refreshNeedsDraw = false;
+    this.#refreshNeedsSurface = false;
 
     if (this.#root) {
       this.#root.remove();
@@ -93,11 +103,10 @@ export class SpoilerPainterFallback {
       this.#inlinePositioning = false;
     }
 
-    this.el.style.overflow = this.#inlineOverflow;
     this.#mode = "none";
   }
 
-  updateSurface(gap: number | boolean | undefined): SurfaceResult {
+  updateSurface(gap: number | boolean | undefined, draw = true): boolean {
     if (typeof document === "undefined") return false;
 
     const mode = getComputedStyle(this.el).getPropertyValue("display") === "inline" ? "inline" : "block";
@@ -106,28 +115,28 @@ export class SpoilerPainterFallback {
     }
 
     this.#lastGap = gap ?? this.#defaultGap;
-    this.#dpr = Math.max(1, Math.round(globalThis.devicePixelRatio || 1));
+    this.#dpr = Math.max(1, globalThis.devicePixelRatio || 1);
 
-    if (!this.syncGeometry()) {
-      return false;
-    }
-
+    this.syncGeometry();
     this.el.style.setProperty("--gap", this.getGap(mode, this.#lastGap));
     this.attachViewportListeners(mode === "inline");
-    this.drawFrame();
+    if (draw) {
+      this.drawFrame();
+    }
 
     return true;
   }
 
-  show(duration: number) {
-    if (!this.updateSurface(this.#lastGap) || !this.#root) {
+  show(duration: number, draw = true) {
+    if (!this.updateSurface(this.#lastGap, draw) || !this.#root) {
       this.el.style.setProperty("background", "var(--fallback)");
-      return;
+      return false;
     }
 
     this.el.style.removeProperty("background");
     this.#root.style.transitionDuration = `${duration}s`;
     this.#root.style.opacity = "1";
+    return true;
   }
 
   hide(duration: number) {
@@ -140,11 +149,9 @@ export class SpoilerPainterFallback {
   }
 
   syncGeometry() {
-    if (!this.#root || this.#mode === "none") return false;
+    if (!this.#root || this.#mode === "none") return;
 
     const layout = this.getLayout(this.#mode);
-    if (!layout) return false;
-
     this.#layout = layout;
 
     if (this.#mode === "inline") {
@@ -155,7 +162,6 @@ export class SpoilerPainterFallback {
     }
 
     this.syncCanvases(layout.fragments);
-    return true;
   }
 
   drawFrame() {
@@ -165,23 +171,13 @@ export class SpoilerPainterFallback {
 
       if (width <= 0 || height <= 0) return;
 
-      ctx.clearRect(0, 0, width, height);
       this.#painter.paint(ctx, { width, height }, this.getPropertyMap());
     });
   }
 
   getDensity() {
     const rawDensity = parseFloat(this.el.style.getPropertyValue("--density"));
-    const density = Number.isFinite(rawDensity) ? rawDensity : this.#defaultDensity;
-    const accent = this.el.style.getPropertyValue("--accent") || "";
-    const parts = accent.trim().split(/\s+/);
-    const lightness = parseFloat(parts[2] || "");
-
-    if (Number.isFinite(lightness) && lightness > 50) {
-      return density * 1.7;
-    }
-
-    return density;
+    return Number.isFinite(rawDensity) ? rawDensity : this.#defaultDensity;
   }
 
   ensureSurface(mode: Exclude<FallbackMode, "none">) {
@@ -206,19 +202,16 @@ export class SpoilerPainterFallback {
         this.#inlinePositioning = true;
       }
 
-      this.#inlineOverflow = this.el.style.overflow;
-      this.el.style.overflow = "hidden";
-
       root.style.position = "absolute";
       root.style.inset = "0";
-      root.style.zIndex = "0";
+      root.style.zIndex = HIGH_Z_INDEX;
       this.el.prepend(root);
     } else {
-      root.style.position = "absolute";
+      root.style.position = "fixed";
       root.style.left = "0";
       root.style.top = "0";
-      root.style.zIndex = "2147483647";
-      document.body.appendChild(root);
+      root.style.zIndex = HIGH_Z_INDEX;
+      this.getInlineRootParent().appendChild(root);
     }
 
     this.#mode = mode;
@@ -226,6 +219,16 @@ export class SpoilerPainterFallback {
     this.#canvases = [];
 
     return true;
+  }
+
+  getInlineRootParent() {
+    const rootNode = this.el.getRootNode();
+
+    if (rootNode instanceof ShadowRoot) {
+      return rootNode;
+    }
+
+    return this.el.ownerDocument.body ?? this.el.ownerDocument.documentElement;
   }
 
   attachViewportListeners(enabled: boolean) {
@@ -243,7 +246,34 @@ export class SpoilerPainterFallback {
     globalThis.removeEventListener("resize", this.#handleResize);
   }
 
-  getLayout(mode: Exclude<FallbackMode, "none">): FallbackLayout | null {
+  scheduleRefresh(options: { draw: boolean; surface?: boolean }) {
+    this.#refreshNeedsDraw = this.#refreshNeedsDraw || options.draw;
+    this.#refreshNeedsSurface = this.#refreshNeedsSurface || Boolean(options.surface);
+
+    if (this.#refreshRAF !== null) return;
+
+    this.#refreshRAF = requestAnimationFrame(() => {
+      this.#refreshRAF = null;
+
+      const needsSurface = this.#refreshNeedsSurface;
+      const needsDraw = this.#refreshNeedsDraw;
+
+      this.#refreshNeedsSurface = false;
+      this.#refreshNeedsDraw = false;
+
+      if (needsSurface) {
+        this.updateSurface(this.#lastGap);
+        return;
+      }
+
+      this.syncGeometry();
+      if (needsDraw) {
+        this.drawFrame();
+      }
+    });
+  }
+
+  getLayout(mode: Exclude<FallbackMode, "none">): FallbackLayout {
     const bounds = this.el.getBoundingClientRect();
     const width = Math.max(1, Math.ceil(bounds.width));
     const height = Math.max(1, Math.ceil(bounds.height));
@@ -258,34 +288,24 @@ export class SpoilerPainterFallback {
       };
     }
 
-    const left = Math.round(bounds.left + globalThis.scrollX);
-    const top = Math.round(bounds.top + globalThis.scrollY);
+    const left = Math.round(bounds.left);
+    const top = Math.round(bounds.top);
 
     const fragments = [...this.el.getClientRects()]
       .map((rect) => ({
-        x: Math.round(rect.left + globalThis.scrollX - left),
-        y: Math.round(rect.top + globalThis.scrollY - top),
+        x: Math.round(rect.left - left),
+        y: Math.round(rect.top - top),
         width: Math.ceil(rect.width),
         height: Math.ceil(rect.height),
       }))
       .filter((rect) => rect.width > 0 && rect.height > 0);
-
-    if (fragments.length === 0) {
-      return {
-        left,
-        top,
-        width,
-        height,
-        fragments: [{ x: 0, y: 0, width, height }],
-      };
-    }
 
     return {
       left,
       top,
       width,
       height,
-      fragments,
+      fragments: fragments.length > 0 ? fragments : [{ x: 0, y: 0, width, height }],
     };
   }
 
@@ -313,8 +333,8 @@ export class SpoilerPainterFallback {
 
     fragments.forEach((fragment, index) => {
       const { canvas } = this.#canvases[index];
-      const pixelWidth = Math.max(1, fragment.width * this.#dpr);
-      const pixelHeight = Math.max(1, fragment.height * this.#dpr);
+      const pixelWidth = Math.max(1, Math.ceil(fragment.width * this.#dpr));
+      const pixelHeight = Math.max(1, Math.ceil(fragment.height * this.#dpr));
 
       canvas.style.left = `${fragment.x}px`;
       canvas.style.top = `${fragment.y}px`;

--- a/src/worklet.d.ts
+++ b/src/worklet.d.ts
@@ -1,0 +1,9 @@
+export class SpoilerPainterWorklet {
+  static get contextOptions(): { alpha: boolean };
+  static get inputProperties(): string[];
+  paint(
+    ctx: CanvasRenderingContext2D,
+    size: { width: number; height: number },
+    props: { get(name: string): string | undefined },
+  ): void;
+}


### PR DESCRIPTION
<img width="424" height="287" alt="spoiled-preview" src="https://github.com/user-attachments/assets/178c11c4-5189-42c0-8dac-cee584ac1d17" />

This replaces the old static-image fallback for non-Houdini browsers with an animated canvas fallback that looks much nicer in Firefox and Safari.

The new fallback keeps the existing Houdini path for supported browsers, but for unsupported ones it now renders animated particles with the same shared painter logic instead of falling back to a static texture.

### Notes:
- the fallback intentionally does not try to mimic intra-word gaps
- split fallback rendering into its own module in `src/SpoilerPainterFallback.ts`