### PR TITLE
0.5.1: fix `spoiled/style.css` export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+package-lock.json
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spoiled",
   "description": "Realistic animated <Spoiler /> component for React",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "Unlicense",
   "main": "esm/index.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,7 @@ const buildLibraryConfig: UserConfig = {
     lib: {
       entry: ["src/index.ts", "src/index_unstyled.ts"],
       formats: ["es"],
+      cssFileName: "style",
     },
     rollupOptions: {
       external: ["react"],


### PR DESCRIPTION
Vite 6+ changed the default `build.lib.cssFileName` from `style` to the
package name, so 0.5.0 shipped `esm/spoiled.css` while the exports map
still pointed at `./esm/style.css`. That made `import "spoiled/style.css"`
unresolvable for /no-css consumers (#7).

Pin `lib.cssFileName: "style"` to restore the documented output filename
and keep the exports map and README in sync.